### PR TITLE
Updates project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <!-- Test suite is validated against this AsciidoctorJ setup -->
+        <!--asciidoctor.maven.plugin.version>2.2.6</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
+        <jruby.version>9.4.5.0</jruby.version>
+-->
         <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
         <jruby.version>9.1.17.0</jruby.version>
@@ -49,22 +53,22 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20240205</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.14.3</version>
+            <version>1.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.slugify</groupId>
             <artifactId>slugify</artifactId>
-            <version>2.5</version>
+            <version>3.0.6</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -77,7 +81,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -87,7 +91,7 @@
             <plugin><!-- Compile jflex lexers -->
                 <groupId>de.jflex</groupId>
                 <artifactId>jflex-maven-plugin</artifactId>
-                <version>1.8.2</version>
+                <version>1.9.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/github/fluorumlabs/asciidocj/impl/AsciidocRenderer.java
+++ b/src/main/java/com/github/fluorumlabs/asciidocj/impl/AsciidocRenderer.java
@@ -10,8 +10,10 @@ import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
@@ -712,7 +714,7 @@ public enum AsciidocRenderer {
     }),
     TABLE_CELL(Node::remove), // Cell contents is handled by TABLE_BLOCK
     TABLE_BLOCK(x -> {
-        DecimalFormat widthFormatter = new DecimalFormat("#.####");
+        DecimalFormat widthFormatter = new DecimalFormat("#.####", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
         JSONArray columns = x.getProperties().optJSONArray("columns:");
         if (columns == null) {
@@ -930,7 +932,7 @@ public enum AsciidocRenderer {
     });
 
     // This entity does not exist :)
-    private static final Slugify slugify = new Slugify().withCustomReplacement("ж", "zh");
+    private static final Slugify slugify = Slugify.builder().customReplacement("ж","zh").build();
 
     private final Consumer<AsciidocElement> processor;
 


### PR DESCRIPTION
I had to keep the Asciidoctor plugin related versions because more recent versions have introduced changes producing different output. That causes the tests to fail.

Not sure what is the better approach. Either accept that `asciidocj` behaves as AsciiDoctor 1.x or update the code to match the AsciiDoctor 2.x behavior.